### PR TITLE
fix: should hide default-content if ng-content is provided

### DIFF
--- a/projects/ngb-filterable-dropdown/src/lib/ngb-filterable-dropdown/ngb-filterable-dropdown.component.scss
+++ b/projects/ngb-filterable-dropdown/src/lib/ngb-filterable-dropdown/ngb-filterable-dropdown.component.scss
@@ -51,17 +51,7 @@
   right: 1em;
 }
 
-Hide
-  the
-  default
-  toggle
-  button
-  text
-  if
-  ng-content
-  is
-  provided
-  .ng-content-wrapper:not(:empty)
-  + .default-content-wrapper {
+// Hide the default toggle button text if ng-contentis provided
+.ng-content-wrapper:not(:empty)+.default-content-wrapper {
   display: none;
 }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/2646053/160125242-3bf6913d-0cab-426d-862f-2a9ced5c7f89.png)

After:

<img width="188" alt="image" src="https://user-images.githubusercontent.com/2646053/160125205-0011295c-cd63-416e-b406-8de12d840878.png">

Fixes #78