### PR TITLE
fix: double scroll bar

### DIFF
--- a/projects/ngb-filterable-dropdown/src/lib/ngb-custom-filterable-dropdown/ngb-custom-filterable-dropdown.component.scss
+++ b/projects/ngb-filterable-dropdown/src/lib/ngb-custom-filterable-dropdown/ngb-custom-filterable-dropdown.component.scss
@@ -8,9 +8,9 @@
 }
 
 .dropdown-menu-inner {
+  z-index: 1000;
   display: flex;
   flex-direction: column;
-  max-height: 231px;
   min-height: 76px;
   height: auto;
 }
@@ -66,12 +66,6 @@
   }
 }
 
-.scroll-container {
-  width: 100%;
-  min-height: 30px;
-  overflow-y: auto;
-}
-
 icon-all,
 icon-none,
 icon-checkmark {
@@ -106,9 +100,15 @@ icon-plus {
   }
 }
 
+.scroll-container {
+  width: 100%;
+  min-height: 30px;
+}
+
 .virtual-scroll-viewport {
+  display: block;
   width: 100%;
   min-width: 100%;
-  max-height: 200px;
+  height: 100%;
   min-height: 40px;
 }


### PR DESCRIPTION
### Description

There was a double scroll bar on windows because of the leftover scroll-container element from before the virtual scroll change.

### Checklist

- [ ] Tested manually
- [ ] Unit tests pass with no errors or warnings
- [ ] Documentation updated (if applicable)
- [ ] Reviewed by at least 1 other contributor
